### PR TITLE
Convert $_SESSION['userlevel'] calls to appropriate functions

### DIFF
--- a/LibreNMS/Authentication/TwoFactor.php
+++ b/LibreNMS/Authentication/TwoFactor.php
@@ -28,6 +28,7 @@
 
 namespace LibreNMS\Authentication;
 
+use Delight\Cookie\Session;
 use LibreNMS\Exceptions\AuthenticationException;
 
 class TwoFactor
@@ -185,7 +186,7 @@ class TwoFactor
 
         // no need to show the form, user doesn't have a token
         if (empty($twofactor)) {
-            set_session('twofactor', true);
+            Session::set('twofactor', true);
             return false;
         }
 
@@ -240,7 +241,7 @@ class TwoFactor
         }
         $twofactor['fails'] = 0;
         set_user_pref('twofactor', $twofactor);
-        set_session('twofactor', true);
+        Session::set('twofactor', true);
         return true;
     }
 

--- a/html/ajax_dash.php
+++ b/html/ajax_dash.php
@@ -17,7 +17,7 @@ require realpath(__DIR__ . '/..') . '/includes/init.php';
 
 set_debug($_REQUEST['debug']);
 
-if (!get_session('authenticated')) {
+if (!session_authenticated()) {
     echo 'unauthenticated';
     exit;
 }

--- a/html/ajax_form.php
+++ b/html/ajax_form.php
@@ -14,12 +14,14 @@
 
 // FUA
 
+use Delight\Cookie\Session;
+
 $init_modules = array('web', 'auth', 'alerts');
 require realpath(__DIR__ . '/..') . '/includes/init.php';
 
 set_debug($_REQUEST['debug']);
 
-if (!get_session('authenticated')) {
+if (!Session::get('authenticated')) {
     echo 'unauthenticated';
     exit;
 }

--- a/html/ajax_list.php
+++ b/html/ajax_list.php
@@ -13,10 +13,12 @@
  * the source code distribution for details.
  */
 
+use Delight\Cookie\Session;
+
 $init_modules = array('web', 'auth');
 require realpath(__DIR__ . '/..') . '/includes/init.php';
 
-if (!get_session('authenticated')) {
+if (!Session::get('authenticated')) {
     echo "Unauthenticated\n";
     exit;
 }

--- a/html/ajax_listports.php
+++ b/html/ajax_listports.php
@@ -15,7 +15,7 @@ require realpath(__DIR__ . '/..') . '/includes/init.php';
 
 set_debug($_REQUEST['debug']);
 
-if (!get_session('authenticated')) {
+if (!session_authenticated()) {
     echo 'unauthenticated';
     exit;
 }

--- a/html/ajax_mapview.php
+++ b/html/ajax_mapview.php
@@ -1,20 +1,22 @@
 <?php
 
+use Delight\Cookie\Session;
+
 $init_modules = array('web', 'auth');
 require realpath(__DIR__ . '/..') . '/includes/init.php';
 
 //availability-map mode view
 if (isset($_REQUEST['map_view'])) {
-    set_session('map_view', $_REQUEST['map_view']);
-    $map_view = array('map_view' => get_session('map_view'));
+    Session::set('map_view', $_REQUEST['map_view']);
+    $map_view = array('map_view' => Session::get('map_view'));
     header('Content-type: text/plain');
     echo json_encode($map_view);
 }
 
 //availability-map device group view
 if (isset($_REQUEST['group_view'])) {
-    set_session('group_view', $_REQUEST['group_view']);
-    $group_view = array('group_view' => get_session('group_view'));
+    Session::set('group_view', $_REQUEST['group_view']);
+    $group_view = array('group_view' => Session::get('group_view'));
     header('Content-type: text/plain');
     echo json_encode($group_view);
 }

--- a/html/ajax_output.php
+++ b/html/ajax_output.php
@@ -20,7 +20,7 @@ if (isset($_SESSION['stage']) && $_SESSION['stage'] == 2) {
     $init_modules = array('web', 'auth', 'alerts');
     require realpath(__DIR__ . '/..') . '/includes/init.php';
 
-    if (!get_session('authenticated')) {
+    if (!Session::get('authenticated')) {
         echo "Unauthenticated\n";
         exit;
     }

--- a/html/ajax_rulesuggest.php
+++ b/html/ajax_rulesuggest.php
@@ -26,7 +26,7 @@
 $init_modules = array('web');
 require realpath(__DIR__ . '/..') . '/includes/init.php';
 
-if (!has_session('authenticated')) {
+if (!session_authenticated()) {
     die('Unauthorized.');
 }
 

--- a/html/ajax_search.php
+++ b/html/ajax_search.php
@@ -5,7 +5,7 @@ require realpath(__DIR__ . '/..') . '/includes/init.php';
 
 set_debug($_REQUEST['debug']);
 
-if (!get_session('authenticated')) {
+if (!Session::get('authenticated')) {
     echo "Unauthenticated\n";
     exit;
 }
@@ -46,7 +46,7 @@ if (isset($_REQUEST['search'])) {
             if (is_admin() === true || is_read() === true) {
                 $results = dbFetchRows("SELECT * FROM `devices` WHERE `hostname` LIKE '%".$search."%' OR `location` LIKE '%".$search."%' OR `sysName` LIKE '%".$search."%' OR `purpose` LIKE '%".$search."%' OR `notes` LIKE '%".$search."%' ORDER BY hostname LIMIT ".$limit);
             } else {
-                $results = dbFetchRows("SELECT * FROM `devices` AS `D`, `devices_perms` AS `P` WHERE `P`.`user_id` = ? AND `P`.`device_id` = `D`.`device_id` AND (`hostname` LIKE '%".$search."%' OR `location` LIKE '%".$search."%') ORDER BY hostname LIMIT ".$limit, array(get_session('user_id')));
+                $results = dbFetchRows("SELECT * FROM `devices` AS `D`, `devices_perms` AS `P` WHERE `P`.`user_id` = ? AND `P`.`device_id` = `D`.`device_id` AND (`hostname` LIKE '%".$search."%' OR `location` LIKE '%".$search."%') ORDER BY hostname LIMIT ".$limit, array(Session::get('user_id')));
             }
 
             if (count($results)) {
@@ -71,7 +71,7 @@ if (isset($_REQUEST['search'])) {
                     if (is_admin() === true || is_read() === true) {
                         $num_ports = dbFetchCell('SELECT COUNT(*) FROM `ports` WHERE device_id = ?', array($result['device_id']));
                     } else {
-                        $num_ports = dbFetchCell('SELECT COUNT(*) FROM `ports` AS `I`, `devices` AS `D`, `devices_perms` AS `P` WHERE `P`.`user_id` = ? AND `P`.`device_id` = `D`.`device_id` AND `I`.`device_id` = `D`.`device_id` AND device_id = ?', array(get_session('user_id'), $result['device_id']));
+                        $num_ports = dbFetchCell('SELECT COUNT(*) FROM `ports` AS `I`, `devices` AS `D`, `devices_perms` AS `P` WHERE `P`.`user_id` = ? AND `P`.`device_id` = `D`.`device_id` AND `I`.`device_id` = `D`.`device_id` AND device_id = ?', array(Session::get('user_id'), $result['device_id']));
                     }
 
                     $device[] = array(
@@ -96,7 +96,7 @@ if (isset($_REQUEST['search'])) {
             if (is_admin() === true || is_read() === true) {
                 $results = dbFetchRows("SELECT `ports`.*,`devices`.* FROM `ports` LEFT JOIN `devices` ON  `ports`.`device_id` =  `devices`.`device_id` WHERE `ifAlias` LIKE '%".$search."%' OR `ifDescr` LIKE '%".$search."%' OR `ifName` LIKE '%".$search."%' ORDER BY ifDescr LIMIT ".$limit);
             } else {
-                $results = dbFetchRows("SELECT DISTINCT(`I`.`port_id`), `I`.*, `D`.`hostname` FROM `ports` AS `I`, `devices` AS `D`, `devices_perms` AS `P`, `ports_perms` AS `PP` WHERE ((`P`.`user_id` = ? AND `P`.`device_id` = `D`.`device_id`) OR (`PP`.`user_id` = ? AND `PP`.`port_id` = `I`.`port_id` AND `I`.`device_id` = `D`.`device_id`)) AND `D`.`device_id` = `I`.`device_id` AND (`ifAlias` LIKE '%".$search."%' OR `ifDescr` LIKE '%".$search."%' OR `ifName` LIKE '%".$search."%') ORDER BY ifDescr LIMIT ".$limit, array(get_session('user_id'), get_session('user_id')));
+                $results = dbFetchRows("SELECT DISTINCT(`I`.`port_id`), `I`.*, `D`.`hostname` FROM `ports` AS `I`, `devices` AS `D`, `devices_perms` AS `P`, `ports_perms` AS `PP` WHERE ((`P`.`user_id` = ? AND `P`.`device_id` = `D`.`device_id`) OR (`PP`.`user_id` = ? AND `PP`.`port_id` = `I`.`port_id` AND `I`.`device_id` = `D`.`device_id`)) AND `D`.`device_id` = `I`.`device_id` AND (`ifAlias` LIKE '%".$search."%' OR `ifDescr` LIKE '%".$search."%' OR `ifName` LIKE '%".$search."%') ORDER BY ifDescr LIMIT ".$limit, array(Session::get('user_id'), Session::get('user_id')));
             }
 
             if (count($results)) {
@@ -142,7 +142,7 @@ if (isset($_REQUEST['search'])) {
             if (is_admin() === true || is_read() === true) {
                 $results = dbFetchRows("SELECT `bgpPeers`.*,`devices`.* FROM `bgpPeers` LEFT JOIN `devices` ON  `bgpPeers`.`device_id` =  `devices`.`device_id` WHERE `astext` LIKE '%".$search."%' OR `bgpPeerIdentifier` LIKE '%".$search."%' OR `bgpPeerRemoteAs` LIKE '%".$search."%' ORDER BY `astext` LIMIT ".$limit);
             } else {
-                $results = dbFetchRows("SELECT `bgpPeers`.*,`D`.* FROM `bgpPeers`, `devices` AS `D`, `devices_perms` AS `P` WHERE `P`.`user_id` = ? AND `P`.`device_id` = `D`.`device_id` AND  `bgpPeers`.`device_id`=`D`.`device_id` AND  (`astext` LIKE '%".$search."%' OR `bgpPeerIdentifier` LIKE '%".$search."%' OR `bgpPeerRemoteAs` LIKE '%".$search."%') ORDER BY `astext` LIMIT ".$limit, array(get_session('user_id')));
+                $results = dbFetchRows("SELECT `bgpPeers`.*,`D`.* FROM `bgpPeers`, `devices` AS `D`, `devices_perms` AS `P` WHERE `P`.`user_id` = ? AND `P`.`device_id` = `D`.`device_id` AND  `bgpPeers`.`device_id`=`D`.`device_id` AND  (`astext` LIKE '%".$search."%' OR `bgpPeerIdentifier` LIKE '%".$search."%' OR `bgpPeerRemoteAs` LIKE '%".$search."%') ORDER BY `astext` LIMIT ".$limit, array(Session::get('user_id')));
             }
 
             if (count($results)) {
@@ -192,7 +192,7 @@ if (isset($_REQUEST['search'])) {
             if (is_admin() === true || is_read() === true) {
                 $results = dbFetchRows("SELECT * FROM `applications` INNER JOIN `devices` ON devices.device_id = applications.device_id WHERE `app_type` LIKE '%".$search."%' OR `hostname` LIKE '%".$search."%' ORDER BY hostname LIMIT ".$limit);
             } else {
-                $results = dbFetchRows("SELECT * FROM `applications` INNER JOIN `devices` AS `D` ON `D`.`device_id` = `applications`.`device_id` INNER JOIN `devices_perms` AS `P` ON `P`.`device_id` = `D`.`device_id` WHERE `P`.`user_id` = ? AND (`app_type` LIKE '%".$search."%' OR `hostname` LIKE '%".$search."%') ORDER BY hostname LIMIT ".$limit, array(get_session('user_id')));
+                $results = dbFetchRows("SELECT * FROM `applications` INNER JOIN `devices` AS `D` ON `D`.`device_id` = `applications`.`device_id` INNER JOIN `devices_perms` AS `P` ON `P`.`device_id` = `D`.`device_id` WHERE `P`.`user_id` = ? AND (`app_type` LIKE '%".$search."%' OR `hostname` LIKE '%".$search."%') ORDER BY hostname LIMIT ".$limit, array(Session::get('user_id')));
             }
 
             if (count($results)) {
@@ -233,7 +233,7 @@ if (isset($_REQUEST['search'])) {
             if (is_admin() === true || is_read() === true) {
                 $results = dbFetchRows("SELECT * FROM `munin_plugins` INNER JOIN `devices` ON devices.device_id = munin_plugins.device_id WHERE `mplug_type` LIKE '%".$search."%' OR `mplug_title` LIKE '%".$search."%' OR `hostname` LIKE '%".$search."%' ORDER BY hostname LIMIT ".$limit);
             } else {
-                $results = dbFetchRows("SELECT * FROM `munin_plugins` INNER JOIN `devices` AS `D` ON `D`.`device_id` = `munin_plugins`.`device_id` INNER JOIN `devices_perms` AS `P` ON `P`.`device_id` = `D`.`device_id` WHERE `P`.`user_id` = ? AND (`mplug_type` LIKE '%".$search."%' OR `mplug_title` LIKE '%".$search."%' OR `hostname` LIKE '%".$search."%') ORDER BY hostname LIMIT ".$limit, array(get_session('user_id')));
+                $results = dbFetchRows("SELECT * FROM `munin_plugins` INNER JOIN `devices` AS `D` ON `D`.`device_id` = `munin_plugins`.`device_id` INNER JOIN `devices_perms` AS `P` ON `P`.`device_id` = `D`.`device_id` WHERE `P`.`user_id` = ? AND (`mplug_type` LIKE '%".$search."%' OR `mplug_title` LIKE '%".$search."%' OR `hostname` LIKE '%".$search."%') ORDER BY hostname LIMIT ".$limit, array(Session::get('user_id')));
             }
 
             if (count($results)) {
@@ -274,7 +274,7 @@ if (isset($_REQUEST['search'])) {
             if (is_admin() === true || is_read() === true) {
                 $results = dbFetchRows("SELECT `ports`.ifType FROM `ports` WHERE `ifType` LIKE '%".$search."%' GROUP BY ifType ORDER BY ifType LIMIT ".$limit);
             } else {
-                $results = dbFetchRows("SELECT `I`.ifType FROM `ports` AS `I`, `devices` AS `D`, `devices_perms` AS `P`, `ports_perms` AS `PP` WHERE ((`P`.`user_id` = ? AND `P`.`device_id` = `D`.`device_id`) OR (`PP`.`user_id` = ? AND `PP`.`port_id` = `I`.`port_id` AND `I`.`device_id` = `D`.`device_id`)) AND `D`.`device_id` = `I`.`device_id` AND (`ifType` LIKE '%".$search."%') GROUP BY ifType ORDER BY ifType LIMIT ".$limit, array(get_session('user_id'), get_session('user_id')));
+                $results = dbFetchRows("SELECT `I`.ifType FROM `ports` AS `I`, `devices` AS `D`, `devices_perms` AS `P`, `ports_perms` AS `PP` WHERE ((`P`.`user_id` = ? AND `P`.`device_id` = `D`.`device_id`) OR (`PP`.`user_id` = ? AND `PP`.`port_id` = `I`.`port_id` AND `I`.`device_id` = `D`.`device_id`)) AND `D`.`device_id` = `I`.`device_id` AND (`ifType` LIKE '%".$search."%') GROUP BY ifType ORDER BY ifType LIMIT ".$limit, array(Session::get('user_id'), Session::get('user_id')));
             }
             if (count($results)) {
                 $found   = 1;
@@ -294,7 +294,7 @@ if (isset($_REQUEST['search'])) {
             if (is_admin() === true || is_read() === true) {
                 $results = dbFetchRows("SELECT `bills`.bill_id, `bills`.bill_name FROM `bills` WHERE `bill_name` LIKE '%".$search."%' OR `bill_notes` LIKE '%".$search."%' LIMIT ".$limit);
             } else {
-                $results = dbFetchRows("SELECT `bills`.bill_id, `bills`.bill_name FROM `bills` INNER JOIN `bill_perms` ON `bills`.bill_id = `bill_perms`.bill_id WHERE `bill_perms`.user_id = ? AND (`bill_name` LIKE '%".$search."%' OR `bill_notes` LIKE '%".$search."%') LIMIT ".$limit, array(get_session('user_id')));
+                $results = dbFetchRows("SELECT `bills`.bill_id, `bills`.bill_name FROM `bills` INNER JOIN `bill_perms` ON `bills`.bill_id = `bill_perms`.bill_id WHERE `bill_perms`.user_id = ? AND (`bill_name` LIKE '%".$search."%' OR `bill_notes` LIKE '%".$search."%') LIMIT ".$limit, array(Session::get('user_id')));
             }
             $json = json_encode($results);
             die($json);

--- a/html/includes/authenticate.inc.php
+++ b/html/includes/authenticate.inc.php
@@ -1,5 +1,7 @@
 <?php
 
+use Delight\Cookie\Cookie;
+use Delight\Cookie\Session;
 use LibreNMS\Authentication\TwoFactor;
 use LibreNMS\Exceptions\AuthenticationException;
 
@@ -19,13 +21,13 @@ if (!is_writable($config['temp_dir'])) {
 // Clear up any old sessions
 dbDelete('session', '`session_expiry` <  ?', array(time()));
 
-\Delight\Cookie\Session::start('Strict');
+Session::start('Strict');
 
 $time = time() - 60 * 60 * 24 * $config['auth_remember'];
-setcookie('sess_id', '', $time, '/', null, $config['secure_cookies']);
-setcookie('PHPSESSID', '', $time, '/', null, $config['secure_cookies']);
-setcookie('token', '', $time, '/', null, $config['secure_cookies']);
-setcookie('auth', '', $time, '/', null, $config['secure_cookies']);
+Cookie::setcookie('sess_id', '', $time, '/', null, $config['secure_cookies'], true, 'Strict');
+Cookie::setcookie('PHPSESSID', '', $time, '/', null, $config['secure_cookies'], true, 'Strict');
+Cookie::setcookie('token', '', $time, '/', null, $config['secure_cookies'], true, 'Strict');
+Cookie::setcookie('auth', '', $time, '/', null, $config['secure_cookies'], true, 'Strict');
 
 if ($vars['page'] == 'logout' && session_authenticated()) {
     log_out_user();
@@ -46,8 +48,8 @@ try {
         } elseif (isset($_COOKIE['sess_id'], $_COOKIE['token']) &&
             reauthenticate(clean($_COOKIE['sess_id']), clean($_COOKIE['token']))
         ) {
-            set_session('remember', true);
-            set_session('twofactor', true);
+            Session::set('remember', true);
+            Session::set('twofactor', true);
             // cookie authentication
             log_in_user();
         } else {
@@ -64,10 +66,10 @@ try {
 
             // form authentication
             if (isset($username) && authenticate($username, $password)) {
-                set_session('username', $username);
+                Session::set('username', $username);
 
                 if (isset($_POST['remember'])) {
-                    set_session('remember', $_POST['remember']);
+                    Session::set('remember', $_POST['remember']);
                 }
 
                 if (log_in_user()) {
@@ -84,7 +86,7 @@ try {
     }
 
     dbInsert(
-        array('user' => \Delight\Cookie\Session::get('username'), 'address' => get_client_ip(), 'result' => $auth_message),
+        array('user' => Session::get('username'), 'address' => get_client_ip(), 'result' => $auth_message),
         'authlog'
     );
     log_out_user($auth_message);
@@ -93,8 +95,8 @@ try {
 session_write_close();
 
 // populate the permissions cache
-if (\Delight\Cookie\Session::has('user_id')) {
-    $permissions = permissions_cache(\Delight\Cookie\Session::get('user_id'));
+if (Session::has('user_id')) {
+    $permissions = permissions_cache(Session::get('user_id'));
 }
 
 unset($username, $password);

--- a/html/includes/authentication/ad-authorization.inc.php
+++ b/html/includes/authentication/ad-authorization.inc.php
@@ -1,5 +1,7 @@
 <?php
 
+use Delight\Cookie\Session;
+use LibreNMS\Config;
 use LibreNMS\Exceptions\AuthenticationException;
 
 function init_auth()
@@ -366,36 +368,24 @@ function sid_from_ldap($sid)
 
 function auth_ldap_session_cache_get($attr)
 {
-    global $config;
-
-    $ttl = 300;
-    if ($config['auth_ldap_cache_ttl']) {
-        $ttl = $config['auth_ldap_cache_ttl'];
-    }
-
-    // auth_ldap cache present in this session?
-    if (! isset($_SESSION['auth_ldap'])) {
-        return null;
-    }
-
-    $cache = $_SESSION['auth_ldap'];
-
     // $attr present in cache?
-    if (! isset($cache[$attr])) {
+    if (!Session::has("auth_ldap.$attr.value")) {
         return null;
     }
+
+    $ttl = Config::get('auth_ldap_cach_ttl', 300);
 
     // Value still valid?
-    if (time() - $cache[$attr]['last_updated'] >= $ttl) {
+    if (time() - Session::get("auth_ldap.$attr.updated") >= $ttl) {
         return null;
     }
 
-    return $cache[$attr]['value'];
+    return Session::get("auth_ldap.$attr.value");
 }
 
 
 function auth_ldap_session_cache_set($attr, $value)
 {
-    $_SESSION['auth_ldap'][$attr]['value'] = $value;
-    $_SESSION['auth_ldap'][$attr]['last_updated'] = time();
+    Session::set("auth_ldap.$attr.value", $value);
+    Session::set("auth_ldap.$attr.updated", time());
 }

--- a/html/includes/authentication/functions.php
+++ b/html/includes/authentication/functions.php
@@ -23,6 +23,8 @@
  * @author     Tony Murray <murraytony@gmail.com>
  */
 
+use Delight\Cookie\Cookie;
+use Delight\Cookie\Session;
 use LibreNMS\Authentication\TwoFactor;
 use LibreNMS\Exceptions\AuthenticationException;
 use Phpass\PasswordHash;
@@ -36,11 +38,11 @@ function log_out_user($message = 'Logged Out')
 {
     global $auth_message;
 
-    dbInsert(array('user' => \Delight\Cookie\Session::get('username'), 'address' => get_client_ip(), 'result' => 'Logged Out'), 'authlog');
+    dbInsert(array('user' => Session::get('username'), 'address' => get_client_ip(), 'result' => 'Logged Out'), 'authlog');
 
-    clear_remember_me(\Delight\Cookie\Session::get('username'));
+    clear_remember_me(Session::get('username'));
 
-    \Delight\Cookie\Session::delete('username');
+    Session::delete('username');
 
     $auth_message = $message; // global variable used to display a message to the user
 }
@@ -58,36 +60,32 @@ function log_in_user()
 {
     global $config;
 
-    $tmp_username  = \Delight\Cookie\Session::get('username');
-    $tmp_userid    = \Delight\Cookie\Session::get('user_id');
     // set up variables, but don't override existing ones (ad anonymous bind can only get user_id at login)
-    if (!\Delight\Cookie\Session::has('userlevel')) {
-        set_session('userlevel', get_userlevel($tmp_username));
+    if (!Session::has('userlevel')) {
+        Session::set('userlevel', get_userlevel(Session::get('username')));
     }
 
-    if (!\Delight\Cookie\Session::has('user_id')) {
-        set_session('user_id', get_userid($tmp_username));
+    if (!Session::has('user_id')) {
+        Session::set('user_id', get_userid(Session::get('username')));
     }
 
     // check for valid user_id
-    if ($tmp_userid === false || $tmp_userid < 0) {
+    if (Session::get('user_id') === false || Session::get('user_id') < 0) {
         throw new AuthenticationException('Invalid Credentials');
     }
 
     if (!session_authenticated()) {
         // check twofactor
-        if ($config['twofactor'] === true && !\Delight\Cookie\Session::has('twofactor')) {
+        if ($config['twofactor'] === true && !Session::has('twofactor')) {
             if (TwoFactor::showForm()) {
                 return false; // not done yet, one more cycle to show the 2fa form
             }
         }
 
-        $tmp_twofactor = \Delight\Cookie\Session::get('twofactor', false);
-
         // if two factor isn't enabled or it has passed already ware are logged in
-        if (!$config['twofactor'] || $tmp_twofactor) {
-            set_session('authenticated', true);
-            dbInsert(array('user' => $tmp_username, 'address' => get_client_ip(), 'result' => 'Logged In'), 'authlog');
+        if (!$config['twofactor'] || Session::get('twofactor', false)) {
+            Session::set('authenticated', true);
+            dbInsert(array('user' => Session::get('username'), 'address' => get_client_ip(), 'result' => 'Logged In'), 'authlog');
         }
     }
 
@@ -99,17 +97,6 @@ function log_in_user()
 }
 
 /**
- * Check if the session is authenticated
- *
- * @return bool
- */
-function session_authenticated()
-{
-    $tmp_authenticated = \Delight\Cookie\Session::get('authenticated', false);
-    return isset($tmp_authenticated) && $tmp_authenticated;
-}
-
-/**
  * Set or update the remember me cookie if $_SESSION['remember'] is set
  * If setting a new cookie, $_SESSION['username'] must be set
  */
@@ -117,12 +104,12 @@ function set_remember_me()
 {
     global $config;
 
-    if (!\Delight\Cookie\Session::has('remember', false)) {
+    if (!Session::has('remember')) {
         return;
     }
-    \Delight\Cookie\Session::delete('remember');
+    Session::delete('remember');
 
-    $sess_id = session_id();
+    $sess_id = Session::id();
     $expiration = time() + 60 * 60 * 24 * $config['auth_remember'];
 
     $db_entry = array(
@@ -138,17 +125,17 @@ function set_remember_me()
         $token = strgen();
         $auth = strgen();
         $hasher = new PasswordHash(8, false);
-        $token_id = \Delight\Cookie\Session::get('username') . '|' . $hasher->HashPassword(\Delight\Cookie\Session::get('username') . $token);
+        $token_id = Session::get('username') . '|' . $hasher->HashPassword(Session::get('username') . $token);
 
-        $db_entry['session_username'] = \Delight\Cookie\Session::get('username');
+        $db_entry['session_username'] = Session::get('username');
         $db_entry['session_token'] = $token;
         $db_entry['session_auth'] = $auth;
         dbInsert($db_entry, 'session');
     }
 
-    \Delight\Cookie\Cookie::setcookie('sess_id', $sess_id, $expiration, '/', null, $config['secure_cookies'], true, 'Strict');
-    \Delight\Cookie\Cookie::setcookie('token', $token_id, $expiration, '/', null, $config['secure_cookies'], true, 'Strict');
-    \Delight\Cookie\Cookie::setcookie('auth', $auth, $expiration, '/', null, $config['secure_cookies'], true, 'Strict');
+    Cookie::setcookie('sess_id', $sess_id, $expiration, '/', null, $config['secure_cookies'], true, 'Strict');
+    Cookie::setcookie('token', $token_id, $expiration, '/', null, $config['secure_cookies'], true, 'Strict');
+    Cookie::setcookie('auth', $auth, $expiration, '/', null, $config['secure_cookies'], true, 'Strict');
 }
 
 /**
@@ -171,7 +158,7 @@ function check_remember_me($sess_id, $token)
 
     $hasher = new PasswordHash(8, false);
     if ($hasher->CheckPassword($uname . $session['session_token'], $hash)) {
-        set_session('username', $uname);
+        Session::set('username', $uname);
         return true;
     }
 
@@ -198,7 +185,7 @@ function clear_remember_me($username)
 
     $time = time() - 60 * 60 * 24 * $config['auth_remember']; // time in the past to make sure
 
-    \Delight\Cookie\Cookie::setcookie('sess_id', '', $time, '/', null, $config['secure_cookies'], false, 'Strict');
-    \Delight\Cookie\Cookie::setcookie('token', '', $time, '/', null, $config['secure_cookies'], false, 'Strict');
-    \Delight\Cookie\Cookie::setcookie('auth', '', $time, '/', null, $config['secure_cookies'], false, 'Strict');
+    Cookie::setcookie('sess_id', '', $time, '/', null, $config['secure_cookies'], false, 'Strict');
+    Cookie::setcookie('token', '', $time, '/', null, $config['secure_cookies'], false, 'Strict');
+    Cookie::setcookie('auth', '', $time, '/', null, $config['secure_cookies'], false, 'Strict');
 }

--- a/html/includes/authentication/ldap-authorization.inc.php
+++ b/html/includes/authentication/ldap-authorization.inc.php
@@ -38,6 +38,8 @@
  */
 
 
+use Delight\Cookie\Session;
+use LibreNMS\Config;
 use LibreNMS\Exceptions\AuthenticationException;
 
 function init_auth()
@@ -298,38 +300,26 @@ function get_membername($username)
 
 function auth_ldap_session_cache_get($attr)
 {
-    global $config;
-
-    $ttl = 300;
-    if ($config['auth_ldap_cache_ttl']) {
-        $ttl = $config['auth_ldap_cache_ttl'];
-    }
-
-    // auth_ldap cache present in this session?
-    if (! isset($_SESSION['auth_ldap'])) {
-        return null;
-    }
-
-    $cache = $_SESSION['auth_ldap'];
-
     // $attr present in cache?
-    if (! isset($cache[$attr])) {
+    if (!Session::has("auth_ldap.$attr.value")) {
         return null;
     }
+
+    $ttl = Config::get('auth_ldap_cach_ttl', 300);
 
     // Value still valid?
-    if (time() - $cache[$attr]['last_updated'] >= $ttl) {
+    if (time() - Session::get("auth_ldap.$attr.updated") >= $ttl) {
         return null;
     }
 
-    $cache[$attr]['value'];
+    return Session::get("auth_ldap.$attr.value");
 }
 
 
 function auth_ldap_session_cache_set($attr, $value)
 {
-    $_SESSION['auth_ldap'][$attr]['value'] = $value;
-    $_SESSION['auth_ldap'][$attr]['last_updated'] = time();
+    Session::set("auth_ldap.$attr.value", $value);
+    Session::set("auth_ldap.$attr.updated", time());
 }
 
 

--- a/html/includes/common/availability-map.inc.php
+++ b/html/includes/common/availability-map.inc.php
@@ -12,12 +12,12 @@
  * the source code distribution for details.
  */
 
+use Delight\Cookie\Session;
+
 if (isset($widget_settings['mode_select']) && $widget_settings['mode_select'] !== '') {
     $mode = $widget_settings['mode_select'];
-} elseif (isset($_SESSION["map_view"]) && is_numeric($_SESSION["map_view"])) {
-    $mode = $_SESSION["map_view"];
 } else {
-    $mode = 0;
+    $mode = Session::get('map_view', 0) ;
 }
 
 $select_modes = array(

--- a/html/includes/forms/notifications.inc.php
+++ b/html/includes/forms/notifications.inc.php
@@ -4,12 +4,12 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>. */
 
@@ -29,14 +29,14 @@ if (isset($_REQUEST['notification_id']) && isset($_REQUEST['action'])) {
     if ($_REQUEST['action'] == 'read' && dbInsert(array('notifications_id'=>$_REQUEST['notification_id'],'user_id'=>$_SESSION['user_id'],'key'=>'read','value'=>1), 'notifications_attribs')) {
         $status  = 'ok';
         $message = 'Set as Read';
-    } elseif ($_SESSION['userlevel'] == 10 && $_REQUEST['action'] == 'stick' && dbInsert(array('notifications_id'=>$_REQUEST['notification_id'],'user_id'=>$_SESSION['user_id'],'key'=>'sticky','value'=>1), 'notifications_attribs')) {
+    } elseif (is_admin() && $_REQUEST['action'] == 'stick' && dbInsert(array('notifications_id'=>$_REQUEST['notification_id'],'user_id'=>$_SESSION['user_id'],'key'=>'sticky','value'=>1), 'notifications_attribs')) {
         $status  = 'ok';
         $message = 'Set as Sticky';
-    } elseif ($_SESSION['userlevel'] == 10 && $_REQUEST['action'] == 'unstick' && dbDelete('notifications_attribs', "notifications_id = ? && user_id = ? AND `key`='sticky'", array($_REQUEST['notification_id'],$_SESSION['user_id']))) {
+    } elseif (is_admin() && $_REQUEST['action'] == 'unstick' && dbDelete('notifications_attribs', "notifications_id = ? && user_id = ? AND `key`='sticky'", array($_REQUEST['notification_id'],$_SESSION['user_id']))) {
         $status  = 'ok';
         $message = 'Removed Sticky';
     }
-} elseif ($_REQUEST['action'] == 'create' && $_SESSION['userlevel'] == 10 && (isset($_REQUEST['title']) && isset($_REQUEST['body']))) {
+} elseif (is_admin() && $_REQUEST['action'] == 'create' && (isset($_REQUEST['title']) && isset($_REQUEST['body']))) {
     if (dbInsert(array('title'=>$_REQUEST['title'],'body'=>$_REQUEST['body'],'checksum'=>hash('sha512', $_SESSION['user_id'].'.LOCAL.'.$_REQUEST['title']),'source'=>$_SESSION['user_id']), 'notifications')) {
         $status  = 'ok';
         $message = 'Created';

--- a/html/includes/graphs/customer/auth.inc.php
+++ b/html/includes/graphs/customer/auth.inc.php
@@ -1,7 +1,7 @@
 <?php
 
 // FIXME - wtfbbq
-if ($_SESSION['userlevel'] >= '5' || $auth) {
+if (is_read() || is_admin() || $auth) {
     $id    = mres($vars['id']);
     $title = generate_device_link($device);
     $auth  = true;

--- a/html/includes/graphs/global/auth.inc.php
+++ b/html/includes/graphs/global/auth.inc.php
@@ -1,5 +1,5 @@
 <?php
 
-if ($_SESSION['userlevel'] >= '5') {
+if (is_read() || is_admin()) {
     $auth = 1;
 }

--- a/html/includes/hostbox-menu.inc.php
+++ b/html/includes/hostbox-menu.inc.php
@@ -21,7 +21,7 @@ if (device_permitted($device['device_id'])) {
         <div class="col-xs-1">';
     echo '<a href="'.generate_device_url($device, array('tab' => 'alerts')).'"> <i class="fa fa-exclamation-circle fa-lg icon-theme"  title="View alerts" aria-hidden="true"></i></a> ';
     echo '</div>';
-    if ($_SESSION['userlevel'] >= '7') {
+    if (is_admin()) {
         echo '<div class="col-xs-1">
             <a href="'.generate_device_url($device, array('tab' => 'edit')).'"> <i class="fa fa-pencil fa-lg icon-theme"  title="Edit ports" aria-hidden="true"></i></a>
             </div>';

--- a/html/includes/print-alert-rules.php
+++ b/html/includes/print-alert-rules.php
@@ -71,7 +71,7 @@ echo '<div class="table-responsive">
     </tr>';
 
 echo '<td colspan="7">';
-if ($_SESSION['userlevel'] >= '10') {
+if (is_admin()) {
     echo '<button type="button" class="btn btn-primary btn-sm" data-toggle="modal" data-target="#create-alert" data-device_id="'.$device['device_id'].'"><i class="fa fa-plus"></i> Create new alert rule</button>';
     echo '<i> - OR - </i>';
     echo '<button type="button" class="btn btn-primary btn-sm" data-toggle="modal" data-target="#search_rule_modal" data-device_id="'.$device['device_id'].'"><i class="fa fa-plus"></i> Create rule from collection</button>';
@@ -171,13 +171,13 @@ foreach (dbFetchRows($full_query, $param) as $rule) {
 
     echo '<td><small>Max: '.$rule_extra['count'].'<br />Delay: '.$rule_extra['delay'].'<br />Interval: '.$rule_extra['interval'].'</small></td>';
     echo '<td>';
-    if ($_SESSION['userlevel'] >= '10') {
+    if (is_admin()) {
         echo "<input id='".$rule['id']."' type='checkbox' name='alert-rule' data-orig_class='".$orig_class."' data-orig_colour='".$orig_col."' data-orig_state='".$orig_ico."' data-alert_id='".$rule['id']."' ".$alert_checked." data-size='small' data-content='".$popover_msg."' data-toggle='modal'>";
     }
 
     echo '</td>';
     echo '<td>';
-    if ($_SESSION['userlevel'] >= '10') {
+    if (is_admin()) {
         echo "<div class='btn-group btn-group-sm' role='group'>";
         echo "<button type='button' class='btn btn-primary' data-toggle='modal' data-target='#create-alert' data-device_id='".$rule['device_id']."' data-alert_id='".$rule['id']."' name='edit-alert-rule' data-content='".$popover_msg."' data-container='body'><i class='fa fa-lg fa-pencil' aria-hidden='true'></i></button> ";
         echo "<button type='button' class='btn btn-danger' aria-label='Delete' data-toggle='modal' data-target='#confirm-delete' data-alert_id='".$rule['id']."' name='delete-alert-rule' data-content='".$popover_msg."' data-container='body'><i class='fa fa-lg fa-trash' aria-hidden='true'></i></button>";
@@ -200,7 +200,7 @@ echo '</table>
     </div>';
 
 if ($count < 1) {
-    if ($_SESSION['userlevel'] >= '10') {
+    if (is_admin()) {
         echo '<div class="row">
             <div class="col-sm-12">
             <form role="form" method="post">

--- a/html/includes/print-alert-templates.php
+++ b/html/includes/print-alert-templates.php
@@ -54,7 +54,7 @@ $(document).ready(function() {
         templates: {
         header: '<div id="{{ctx.id}}" class="{{css.header}}"> \
                     <div class="row"> \
-<?php if ($_SESSION['userlevel'] >= '10') { ?>
+<?php if (is_admin()) { ?>
                         <div class="col-sm-8 actionBar"> \
                             <span class="pull-left"> \
                             <button type="button" class="btn btn-primary btn-sm" data-toggle="modal" data-target="#alert-template" data-template_id="">Create new alert template</button> \

--- a/html/includes/print-graph-alerts.inc.php
+++ b/html/includes/print-graph-alerts.inc.php
@@ -20,11 +20,9 @@ if (isset($device['device_id']) && $device['device_id'] > 0) {
     );
 }
 
-if ($_SESSION['userlevel'] >= '5') {
+if (is_read() || is_admin()) {
     $query = "SELECT DATE_FORMAT(time_logged, '".$config['alert_graph_date_format']."') Date, COUNT(alert_log.rule_id) totalCount, alert_rules.severity Severity FROM alert_log,alert_rules WHERE alert_log.rule_id=alert_rules.id AND `alert_log`.`state` != 0 $sql GROUP BY DATE_FORMAT(time_logged, '".$config['alert_graph_date_format']."'),alert_rules.severity";
-}
-
-if ($_SESSION['userlevel'] < '5') {
+} else {
     $query = "SELECT DATE_FORMAT(time_logged, '".$config['alert_graph_date_format']."') Date, COUNT(alert_log.device_id) totalCount, alert_rules.severity Severity FROM alert_log,alert_rules,devices_perms WHERE alert_log.rule_id=alert_rules.id AND `alert_log`.`state` != 0 $sql AND alert_log.device_id = devices_perms.device_id AND devices_perms.user_id = " . $_SESSION['user_id'] . " GROUP BY DATE_FORMAT(time_logged, '".$config['alert_graph_date_format']."'),alert_rules.severity";
 }
 

--- a/html/includes/print-menubar.php
+++ b/html/includes/print-menubar.php
@@ -8,7 +8,7 @@ $service_status   = get_service_status();
 $typeahead_limit  = $config['webui']['global_search_result_limit'];
 $if_alerts        = dbFetchCell("SELECT COUNT(port_id) FROM `ports` WHERE `ifOperStatus` = 'down' AND `ifAdminStatus` = 'up' AND `ignore` = '0'");
 
-if ($_SESSION['userlevel'] >= 5) {
+if (is_read() || is_admin()) {
     $links['count']        = dbFetchCell("SELECT COUNT(*) FROM `links`");
 } else {
     $links['count']       = dbFetchCell("SELECT COUNT(*) FROM `links` AS `L`, `devices` AS `D`, `devices_perms` AS `P` WHERE `P`.`user_id` = ? AND `P`.`device_id` = `D`.`device_id` AND `L`.`local_device_id` = `D`.`device_id`", array($_SESSION['user_id']));
@@ -77,7 +77,7 @@ if ($config['title_image']) {
                 <?php
                 \LibreNMS\Plugins::call('menu');
 
-                if ($_SESSION['userlevel'] >= '10') {
+                if (is_admin()) {
                     if (dbFetchCell("SELECT COUNT(*) from `plugins` WHERE plugin_active = '1'") > 0) {
                         echo('<li role="presentation" class="divider"></li>');
                     }
@@ -177,7 +177,7 @@ if (count($devices_groups) > 0) {
     unset($group);
     echo '</ul></li>';
 }
-if ($_SESSION['userlevel'] >= '10') {
+if (is_admin()) {
     if ($config['show_locations']) {
         if ($config['show_locations_dropdown']) {
             $locations = getlocations();
@@ -242,7 +242,7 @@ if (($service_status[1] > 0) || ($service_status[2] > 0)) {
     }
 }
 
-if ($_SESSION['userlevel'] >= '10') {
+if (is_admin()) {
     echo('
             <li role="presentation" class="divider"></li>
             <li><a href="addsrv/"><i class="fa fa-plus fa-fw fa-lg" aria-hidden="true"></i> Add Service</a></li>');
@@ -285,7 +285,7 @@ if ($config['enable_pseudowires']) {
 ?>
 <?php
 
-if ($_SESSION['userlevel'] >= '5') {
+if (is_read() || is_admin()) {
     echo('            <li role="presentation" class="divider"></li>');
     if ($config['int_customers']) {
         echo('            <li><a href="customers/"><i class="fa fa-users fa-fw fa-lg" aria-hidden="true"></i> Customers</a></li>');
@@ -433,7 +433,7 @@ if (!empty($valid_wireless_types)) {
 
 $app_list = dbFetchRows("SELECT DISTINCT(`app_type`) AS `app_type` FROM `applications` ORDER BY `app_type`");
 
-if ($_SESSION['userlevel'] >= '5' && count($app_list) > "0") {
+if ((is_read() || is_admin()) && count($app_list) > "0") {
 ?>
         <li class="dropdown">
           <a href="apps/" class="dropdown-toggle" data-hover="dropdown" data-toggle="dropdown"><i class="fa fa-tasks fa-fw fa-lg fa-nav-icons hidden-md" aria-hidden="true"></i> <span class="hidden-sm">Apps</span></a>
@@ -472,7 +472,7 @@ $options['type'] = 'Cisco-OTV';
 $otv = $component->getComponents(null, $options);
 $routing_count['cisco-otv'] = count($otv);
 
-if ($_SESSION['userlevel'] >= '5' && ($routing_count['bgp']+$routing_count['ospf']+$routing_count['cef']+$routing_count['vrf']+$routing_count['cisco-otv']) > "0") {
+if ((is_read() || is_admin()) && ($routing_count['bgp']+$routing_count['ospf']+$routing_count['cef']+$routing_count['vrf']+$routing_count['cisco-otv']) > "0") {
 ?>
         <li class="dropdown">
           <a href="routing/" class="dropdown-toggle" data-hover="dropdown" data-toggle="dropdown"><i class="fa fa-random fa-fw fa-lg fa-nav-icons hidden-md" aria-hidden="true"></i> <span class="hidden-sm">Routing</span></a>
@@ -480,12 +480,12 @@ if ($_SESSION['userlevel'] >= '5' && ($routing_count['bgp']+$routing_count['ospf
 <?php
     $separator = 0;
 
-if ($_SESSION['userlevel'] >= '5' && $routing_count['vrf']) {
+if ((is_read() || is_admin()) && $routing_count['vrf']) {
     echo('            <li><a href="routing/protocol=vrf/"><i class="fa fa-arrows fa-fw fa-lg" aria-hidden="true"></i> VRFs</a></li>');
     $separator++;
 }
 
-if ($_SESSION['userlevel'] >= '5' && $routing_count['ospf']) {
+if ((is_read() || is_admin()) && $routing_count['ospf']) {
     if ($separator) {
         echo('            <li role="presentation" class="divider"></li>');
         $separator = 0;
@@ -495,7 +495,7 @@ if ($_SESSION['userlevel'] >= '5' && $routing_count['ospf']) {
 }
 
     // Cisco OTV Links
-if ($_SESSION['userlevel'] >= '5' && $routing_count['cisco-otv']) {
+if ((is_read() || is_admin()) && $routing_count['cisco-otv']) {
     if ($separator) {
         echo('            <li role="presentation" class="divider"></li>');
         $separator = 0;
@@ -505,7 +505,7 @@ if ($_SESSION['userlevel'] >= '5' && $routing_count['cisco-otv']) {
 }
 
     // BGP Sessions
-if ($_SESSION['userlevel'] >= '5' && $routing_count['bgp']) {
+if ((is_read() || is_admin()) && $routing_count['bgp']) {
     if ($separator) {
         echo('            <li role="presentation" class="divider"></li>');
         $separator = 0;
@@ -516,7 +516,7 @@ if ($_SESSION['userlevel'] >= '5' && $routing_count['bgp']) {
 }
 
     // CEF info
-if ($_SESSION['userlevel'] >= '5' && $routing_count['cef']) {
+if ((is_read() || is_admin()) && $routing_count['cef']) {
     if ($separator) {
         echo('            <li role="presentation" class="divider"></li>');
         $separator = 0;
@@ -563,7 +563,7 @@ if ($alerts['active_count'] > 0) {
               <li><a href="<?php echo(generate_url(array('page'=>'alert-log'))); ?>"><i class="fa fa-file-text fa-fw fa-lg" aria-hidden="true"></i> Alert History</a></li>
               <li><a href="<?php echo(generate_url(array('page'=>'alert-stats'))); ?>"><i class="fa fa-bar-chart fa-fw fa-lg" aria-hidden="true"></i> Statistics</a></li>
                 <?php
-                if ($_SESSION['userlevel'] >= '10') {
+                if (is_admin()) {
                     ?>
                   <li><a href="<?php echo(generate_url(array('page'=>'alert-rules'))); ?>"><i class="fa fa-list fa-fw fa-lg" aria-hidden="true"></i> Alert Rules</a></li>
                   <li><a href="<?php echo(generate_url(array('page'=>'alert-schedule'))); ?>"><i class="fa fa-calendar fa-fw fa-lg" aria-hidden="true"></i> Scheduled Maintenance</a></li>
@@ -621,14 +621,14 @@ if ($_SESSION['authenticated']) {
         <a href="#" class="dropdown-toggle" data-hover="dropdown" data-toggle="dropdown" style="margin-left:5px"><i class="fa fa-cog fa-fw fa-lg fa-nav-icons" aria-hidden="true"></i> <span class="visible-xs-inline-block">Settings</span></a>
         <ul class="dropdown-menu">
 <?php
-if ($_SESSION['userlevel'] >= '10') {
+if (is_admin()) {
     echo('<li><a href="settings/"><i class="fa fa-cogs fa-fw fa-lg" aria-hidden="true"></i> Global Settings</a></li>');
 }
 
 ?>
           <li role="presentation" class="divider"></li>
 
-<?php if ($_SESSION['userlevel'] >= '10') {
+<?php if (is_admin()) {
     if (auth_usermanagement()) {
         echo('
            <li><a href="adduser/"><i class="fa fa-user-plus fa-fw fa-lg" aria-hidden="true"></i> Add User</a></li>

--- a/html/includes/reports/alert-log.pdf.inc.php
+++ b/html/includes/reports/alert-log.pdf.inc.php
@@ -13,7 +13,7 @@ if ($_GET['string']) {
     $param[] = '%'.$_GET['string'].'%';
 }
 
-if ($_SESSION['userlevel'] >= '5') {
+if (is_read() || is_admin()) {
     $query = " FROM `alert_log` AS E LEFT JOIN devices AS D ON E.device_id=D.device_id RIGHT JOIN alert_rules AS R ON E.rule_id=R.id WHERE $where ORDER BY `humandate` DESC";
 } else {
     $query   = " FROM `alert_log` AS E LEFT JOIN devices AS D ON E.device_id=D.device_id RIGHT JOIN alert_rules AS R ON E.rule_id=R.id RIGHT JOIN devices_perms AS P ON E.device_id = P.device_id WHERE $where AND P.user_id = ? ORDER BY `humandate` DESC";

--- a/html/includes/table/alert-schedule.inc.php
+++ b/html/includes/table/alert-schedule.inc.php
@@ -15,7 +15,7 @@
 $where = 1;
 
 $sql = " FROM `alert_schedule` AS S WHERE $where";
-if ($_SESSION['userlevel'] < '5') {
+if (is_normal_user()) {
     $param[] = $_SESSION['user_id'];
 }
 
@@ -55,7 +55,7 @@ foreach (dbFetchRows($sql, $param) as $schedule) {
         if ($end < $now) {
             $status = 1;
         }
-    
+
         if ($now >= $start && $now < $end) {
             $status = 2;
         }

--- a/html/includes/table/alertlog.inc.php
+++ b/html/includes/table/alertlog.inc.php
@@ -12,7 +12,7 @@ if ($_POST['state'] >= 0) {
     $param[] = mres($_POST['state']);
 }
 
-if ($_SESSION['userlevel'] >= '5') {
+if (is_read() || is_admin()) {
     $sql = " FROM `alert_log` AS E LEFT JOIN devices AS D ON E.device_id=D.device_id RIGHT JOIN alert_rules AS R ON E.rule_id=R.id WHERE $where";
 } else {
     $sql     = " FROM `alert_log` AS E LEFT JOIN devices AS D ON E.device_id=D.device_id RIGHT JOIN alert_rules AS R ON E.rule_id=R.id RIGHT JOIN devices_perms AS P ON E.device_id = P.device_id WHERE $where AND P.user_id = ?";

--- a/html/includes/table/devices.inc.php
+++ b/html/includes/table/devices.inc.php
@@ -171,7 +171,7 @@ foreach (dbFetchRows($sql, $param) as $device) {
                 <div class="col-xs-1"><a href="' . generate_device_url($device, array('tab' => 'alerts')) . '"> <i class="fa fa-exclamation-circle fa-lg icon-theme" title="View alerts"></i></a></div>
     ';
 
-    if ($_SESSION['userlevel'] >= '7') {
+    if (is_admin()) {
         $actions .= '<div class="col-xs-1"><a href="' . generate_device_url($device, array('tab' => 'edit')) . '"> <i class="fa fa-pencil fa-lg icon-theme" title="Edit device"></i></a></div>';
     }
 

--- a/html/includes/table/eventlog.inc.php
+++ b/html/includes/table/eventlog.inc.php
@@ -17,7 +17,7 @@ if ($_POST['string']) {
     $param[] = '%'.$_POST['string'].'%';
 }
 
-if ($_SESSION['userlevel'] >= '5') {
+if (is_read() || is_admin()) {
     $sql = " FROM `eventlog` AS E LEFT JOIN `devices` AS `D` ON `E`.`host`=`D`.`device_id` WHERE $where";
 } else {
     $sql     = " FROM `eventlog` AS E, devices_perms AS P WHERE $where AND E.host = P.device_id AND P.user_id = ?";

--- a/html/includes/table/inventory.inc.php
+++ b/html/includes/table/inventory.inc.php
@@ -5,7 +5,7 @@ $param = array();
 
 
 
-if ($_SESSION['userlevel'] >= '5') {
+if (is_read() || is_admin()) {
     $sql = " FROM entPhysical AS E, devices AS D WHERE $where AND D.device_id = E.device_id";
 } else {
     $sql     = " FROM entPhysical AS E, devices AS D, devices_perms AS P WHERE $where AND D.device_id = E.device_id AND P.device_id = D.device_id AND P.user_id = ?";

--- a/html/includes/table/ports.inc.php
+++ b/html/includes/table/ports.inc.php
@@ -147,7 +147,7 @@ foreach (dbFetchRows($query, $param) as $port) {
     $actions .= generate_device_url($device, array('tab' => 'alerts'));
     $actions .= '"><i class="fa fa-exclamation-circle fa-lg icon-theme" title="View alerts" aria-hidden="true"></i></a></div>';
 
-    if ($_SESSION['userlevel'] >= '7') {
+    if (is_admin()) {
         $actions .= '<div class="col-xs-1"><a href="';
         $actions .= generate_device_url($device, array('tab' => 'edit', 'section' => 'ports'));
         $actions .= '"><i class="fa fa-pencil fa-lg icon-theme" title="Edit ports" aria-hidden="true"></i></a></div>';

--- a/html/includes/table/syslog.inc.php
+++ b/html/includes/table/syslog.inc.php
@@ -32,7 +32,7 @@ if (!empty($_POST['to'])) {
     $param[] = $_POST['to'];
 }
 
-if ($_SESSION['userlevel'] >= '5') {
+if (is_read() || is_admin()) {
     $sql  = 'FROM syslog AS S';
     $sql .= ' WHERE '.$where;
 } else {

--- a/html/install.php
+++ b/html/install.php
@@ -1,4 +1,8 @@
 <?php
+
+use Delight\Cookie\Cookie;
+use Delight\Cookie\Session;
+
 session_start();
 if (empty($_POST) && !empty($_SESSION) && !isset($_REQUEST['stage'])) {
     $_POST = $_SESSION;
@@ -81,11 +85,8 @@ if ($stage == 4) {
         $msg = "config.php still doesn't exist";
         $stage = 5;
     } else {
-        // all done, remove all traces of the install session
-        session_unset();
-        session_destroy();
-        setcookie(session_name(), '', 0, '/');
-        session_regenerate_id(true);
+        Cookie::setcookie(session_name(), '', 0, '/', null, $config['secure_cookies'], true, 'Strict');
+        Session::regenerate(true);
     }
 }
 

--- a/html/netcmd.php
+++ b/html/netcmd.php
@@ -46,7 +46,7 @@ if ($_GET['query'] && $_GET['cmd']) {
                 break;
 
             case 'nmap':
-                if ($_SESSION['userlevel'] != '10') {
+                if (!is_admin() || is_demo_user()) {
                     echo 'insufficient privileges';
                 } else {
                     $cmd = $config['nmap']." $host";

--- a/html/pages/addhost.inc.php
+++ b/html/pages/addhost.inc.php
@@ -4,7 +4,7 @@ use LibreNMS\Exceptions\HostUnreachableException;
 
 $no_refresh = true;
 
-if ($_SESSION['userlevel'] < 10) {
+if (!is_admin()) {
     include 'includes/error-no-perm.inc.php';
 
     exit;
@@ -15,7 +15,7 @@ if ($_POST['hostname']) {
             <div class="col-sm-3">
             </div>
             <div class="col-sm-6">';
-    if ($_SESSION['userlevel'] > '5') {
+    if (is_admin()) {
         // Settings common to SNMPv2 & v3
         $hostname = mres($_POST['hostname']);
         if ($_POST['port']) {

--- a/html/pages/addsrv.inc.php
+++ b/html/pages/addsrv.inc.php
@@ -1,10 +1,10 @@
 <?php
 
-if ($_SESSION['userlevel'] < '10') {
+if (!is_admin()) {
     include 'includes/error-no-perm.inc.php';
 } else {
     if ($vars['addsrv']) {
-        if ($_SESSION['userlevel'] >= '10') {
+        if (is_admin()) {
             $updated = '1';
 
             $service_id = add_service($vars['device'], $vars['type'], $vars['descr'], $vars['ip'], $vars['params'], 0);

--- a/html/pages/adduser.inc.php
+++ b/html/pages/adduser.inc.php
@@ -2,9 +2,9 @@
 
 $no_refresh = true;
 
-if ($_SESSION['userlevel'] < '10') {
+if (!is_admin()) {
     include 'includes/error-no-perm.inc.php';
-} elseif ($_SESSION['userlevel'] == 11) {
+} elseif (is_demo_user()) {
     demo_account();
 } else {
     echo '<h3>Add User</h3>';
@@ -102,7 +102,7 @@ if ($_SESSION['userlevel'] < '10') {
     <div class='col-sm-6'>
     </div>
   </div>";
-    
+
     echo '</form>';
     } else {
         echo '<span class="red">Auth module does not allow user management!</span><br />';

--- a/html/pages/authlog.inc.php
+++ b/html/pages/authlog.inc.php
@@ -1,6 +1,6 @@
 <?php
 echo "<h3>Authlog</h3>";
-if ($_SESSION['userlevel'] >= '10') {
+if (is_admin()) {
     echo '<table id="authlogtable" class="table table-hover table-condensed">';
     echo "<thead><th data-column-id='timestamp'>Timestamp</th><th data-column-id='user'>User</th><th data-column-id='ip'>IP Address</th><th data-column-id='authres'>Result</th></thead><tbody>";
     foreach (dbFetchRows("SELECT *,DATE_FORMAT(datetime, '".$config['dateformat']['mysql']['compact']."') as humandate  FROM `authlog` ORDER BY `datetime` DESC LIMIT 0,250") as $entry) {

--- a/html/pages/bill.inc.php
+++ b/html/pages/bill.inc.php
@@ -2,7 +2,7 @@
 
 $bill_id = mres($vars['bill_id']);
 
-if ($_SESSION['userlevel'] >= '10') {
+if (is_admin()) {
     include 'pages/bill/actions.inc.php';
 }
 
@@ -59,7 +59,7 @@ if (bill_permitted($bill_id)) {
         AND D.device_id = P.device_id',
         array($bill_id)
     );
-    
+
     if (!$vars['view']) {
         $vars['view'] = 'quick';
     }
@@ -85,11 +85,11 @@ if (bill_permitted($bill_id)) {
 
         echo '</div></div>';
     }//end print_port_list
-    
+
 ?>
 
     <h2><?php   echo "Bill: ${bill_data['bill_name']}"; ?></h2>
-    
+
 <?php
     print_optionbar_start();
     echo "<strong>Bill</strong> &raquo; ";
@@ -99,7 +99,7 @@ if (bill_permitted($bill_id)) {
         'transfer' => 'Transfer Graphs',
         'history' => 'Historical Graphs'
     );
-    if ($_SESSION['userlevel'] >= '10') {
+    if (is_admin()) {
         $menu_options['edit'] = 'Edit';
         $menu_options['delete'] = 'Delete';
         $menu_options['reset'] = 'Reset';
@@ -118,16 +118,16 @@ if (bill_permitted($bill_id)) {
 
         $sep = ' | ';
     }
-    
+
     echo '<div style="font-weight: bold; float: right;"><a href="'.generate_url(array('page' => 'bills')).'/"><i class="fa fa-arrow-left fa-lg icon-theme" aria-hidden="true"></i> Back to Bills</a></div>';
 
     print_optionbar_end();
 
-    if ($vars['view'] == 'edit' && $_SESSION['userlevel'] >= '10') {
+    if ($vars['view'] == 'edit' && is_admin()) {
         include 'pages/bill/edit.inc.php';
-    } elseif ($vars['view'] == 'delete' && $_SESSION['userlevel'] >= '10') {
+    } elseif ($vars['view'] == 'delete' && is_admin()) {
         include 'pages/bill/delete.inc.php';
-    } elseif ($vars['view'] == 'reset' && $_SESSION['userlevel'] >= '10') {
+    } elseif ($vars['view'] == 'reset' && is_admin()) {
         include 'pages/bill/reset.inc.php';
     } elseif ($vars['view'] == 'history') {
         include 'pages/bill/history.inc.php';
@@ -261,7 +261,7 @@ if ($vars['view'] == 'accurate') {
     </div>
     <?php echo $bi ?>
     </div>
-    
+
     <div class="panel panel-default">
     <div class="panel-heading">
         <h3 class="panel-title">24 Hour View</h3>
@@ -274,7 +274,7 @@ if ($vars['view'] == 'accurate') {
         <h3 class="panel-title">Monthly View</h3>
     </div>
     <?php echo $mi ?>
-    </div>    
+    </div>
 <?php
     } //end if
 } else {

--- a/html/pages/bills.inc.php
+++ b/html/pages/bills.inc.php
@@ -3,11 +3,11 @@
 $no_refresh = true;
 
 if ($_POST['addbill'] == 'yes') {
-    if ($_SESSION['userlevel'] < 10) {
+    if (!is_admin()) {
         include 'includes/error-no-perm.inc.php';
         exit;
     }
-    
+
     $updated = '1';
 
     if (isset($_POST['bill_quota']) or isset($_POST['bill_cdr'])) {
@@ -78,7 +78,7 @@ if ($_POST['addbill'] == 'yes') {
     if (is_numeric($bill_id) && is_numeric($_POST['port_id'])) {
         dbInsert(array('bill_id' => $bill_id, 'port_id' => $_POST['port_id']), 'bill_ports');
     }
-    
+
     header('Location: ' . generate_url(array('page' => 'bill', 'bill_id' => $bill_id, 'view' => 'edit')));
     exit();
 }
@@ -109,14 +109,14 @@ include 'includes/modal/new_bill.inc.php';
         </table>
     </div>
 </div>
-    
+
 <script type="text/html" id="table-header">
     <div id="{{ctx.id}}" class="{{css.header}}">
         <div class="row">
             <div class="col-sm-4">
-            <?php if ($_SESSION['userlevel'] >= 10) {  ?>
+            <?php if (is_admin()) {  ?>
                 <button type="button" class="btn btn-default btn-sm" data-toggle="modal" data-target="#create-bill"><i class="fa fa-plus"></i> Create Bill</button>
-            <?php } ?>     
+            <?php } ?>
             </div>
             <div class="col-sm-8 actionBar">
                 <span class="form-inline" id="table-filters">
@@ -151,7 +151,7 @@ include 'includes/modal/new_bill.inc.php';
         </div>
     </div>
 </script>
-    
+
 <script type="text/javascript">
     var grid = $('#bills-list').bootgrid({
        ajax: true,
@@ -172,12 +172,12 @@ include 'includes/modal/new_bill.inc.php';
     }).on("loaded.rs.jquery.bootgrid", function() {
     });
     $('#table-filters select').on('change', function() { grid.bootgrid('reload'); });
-        
+
 <?php
 if ($vars['view'] == 'add') {
 ?>
 $(function() {
-    $('#create-bill').modal('show');    
+    $('#create-bill').modal('show');
 });
 <?php
 }

--- a/html/pages/delhost.inc.php
+++ b/html/pages/delhost.inc.php
@@ -1,13 +1,13 @@
 <?php
 
-if ($_SESSION['userlevel'] < 10) {
+if (!is_admin()) {
     require 'includes/error-no-perm.inc.php';
     exit;
 }
 
 $pagetitle[] = "Delete device";
 
-if ($_SESSION['userlevel'] == 11) {
+if (is_demo_user()) {
     demo_account();
 } else {
     if (is_numeric($_REQUEST['id'])) {

--- a/html/pages/deluser.inc.php
+++ b/html/pages/deluser.inc.php
@@ -2,7 +2,7 @@
 
 echo '<div style="margin: 10px;">';
 
-if ($_SESSION['userlevel'] < 10 || $_SESSION['userlevel'] > 10) {
+if (!is_admin() || is_demo_user()) {
     include 'includes/error-no-perm.inc.php';
 } else {
     echo '<h3>Delete User</h3>';

--- a/html/pages/device/edit.inc.php
+++ b/html/pages/device/edit.inc.php
@@ -7,7 +7,7 @@ $link_array = array('page'    => 'device',
     'device'  => $device['device_id'],
     'tab' => 'edit');
 
-if ($_SESSION['userlevel'] < '7') {
+if (!is_admin()) {
     print_error("Insufficient Privileges");
 } else {
     $panes['device']   = 'Device Settings';

--- a/html/pages/device/edit/alerts.inc.php
+++ b/html/pages/device/edit/alerts.inc.php
@@ -1,6 +1,6 @@
 <?php
 if ($_POST['editing']) {
-    if ($_SESSION['userlevel'] > '7') {
+    if (is_admin()) {
         $override_sysContact_bool = mres($_POST['override_sysContact']);
         if (isset($_POST['sysContact'])) {
             $override_sysContact_string = mres($_POST['sysContact']);

--- a/html/pages/device/edit/device.inc.php
+++ b/html/pages/device/edit/device.inc.php
@@ -1,6 +1,6 @@
 <?php
 if ($_POST['editing']) {
-    if ($_SESSION['userlevel'] > "7") {
+    if (is_admin()) {
         $updated = 0;
 
         $override_sysLocation_bool = mres($_POST['override_sysLocation']);

--- a/html/pages/device/edit/ipmi.inc.php
+++ b/html/pages/device/edit/ipmi.inc.php
@@ -1,7 +1,7 @@
 <?php
 
 if ($_POST['editing']) {
-    if ($_SESSION['userlevel'] > '7') {
+    if (is_admin()) {
         $ipmi_hostname = mres($_POST['ipmi_hostname']);
         $ipmi_username = mres($_POST['ipmi_username']);
         $ipmi_password = mres($_POST['ipmi_password']);

--- a/html/pages/device/edit/services.inc.php
+++ b/html/pages/device/edit/services.inc.php
@@ -2,7 +2,7 @@
 
 if (is_admin() === true || is_read() === true) {
     if ($vars['addsrv']) {
-        if ($_SESSION['userlevel'] >= '10') {
+        if (is_admin()) {
             $updated = '1';
 
             $service_id = add_service($vars['device'], $vars['type'], $vars['descr'], $vars['ip'], $vars['params'], 0);

--- a/html/pages/device/edit/snmp.inc.php
+++ b/html/pages/device/edit/snmp.inc.php
@@ -1,7 +1,7 @@
 <?php
 
 if ($_POST['editing']) {
-    if ($_SESSION['userlevel'] > '7') {
+    if (is_admin()) {
         $no_checks    = ($_POST['no_checks'] == 'on');
         $community    = mres($_POST['community']);
         $snmpver      = mres($_POST['snmpver']);
@@ -49,7 +49,7 @@ if ($_POST['editing']) {
         $device_tmp = deviceArray($device['hostname'], $community, $snmpver, $port, $transport, $v3, $port_assoc_mode);
         if ($no_checks === true || isSNMPable($device_tmp)) {
             $rows_updated = dbUpdate($update, 'devices', '`device_id` = ?', array($device['device_id']));
-            
+
             $max_repeaters_set = false;
             $max_oid_set = false;
 

--- a/html/pages/device/port.inc.php
+++ b/html/pages/device/port.inc.php
@@ -227,7 +227,7 @@ if (dbFetchCell("SELECT COUNT(*) FROM juniAtmVp WHERE port_id = '".$port['port_i
     }
 }//end if
 
-if ($_SESSION['userlevel'] >= '10' && $config['enable_billing'] == 1) {
+if (is_admin() && $config['enable_billing'] == 1) {
     $bills = dbFetchRows("SELECT `bill_id` FROM `bill_ports` WHERE `port_id`=?", array($port['port_id']));
     if (count($bills) === 1) {
         echo "<span style='float: right;'><a href='" . generate_url(array('page' => 'bill','bill_id' => $bills[0]['bill_id'])) . "'><i class='fa fa-money fa-lg icon-theme' aria-hidden='true'></i> View Bill</a></span>";

--- a/html/pages/edituser.inc.php
+++ b/html/pages/edituser.inc.php
@@ -8,7 +8,7 @@ echo "<div style='margin: 10px;'>";
 
 $pagetitle[] = 'Edit user';
 
-if ($_SESSION['userlevel'] != '10') {
+if (!is_admin() || is_demo_user()) {
     include 'includes/error-no-perm.inc.php';
 } else {
     if ($vars['user_id'] && !$vars['edit']) {
@@ -241,7 +241,7 @@ if ($_SESSION['userlevel'] != '10') {
         </form>
         </div>";
     } elseif ($vars['user_id'] && $vars['edit']) {
-        if ($_SESSION['userlevel'] == 11) {
+        if (is_demo_user()) {
             demo_account();
         } else {
             if (!empty($vars['new_level'])) {

--- a/html/pages/eventlog.inc.php
+++ b/html/pages/eventlog.inc.php
@@ -4,7 +4,7 @@ $no_refresh = true;
 
 $param = array();
 
-if ($vars['action'] == 'expunge' && $_SESSION['userlevel'] >= '10') {
+if ($vars['action'] == 'expunge' && is_admin()) {
     dbQuery('TRUNCATE TABLE `eventlog`');
     print_message('Event log truncated');
 }

--- a/html/pages/front/example2.php
+++ b/html/pages/front/example2.php
@@ -102,7 +102,7 @@ echo '</div>
     <td bgcolor=#e5e5e5 width=275 valign=top>';
 
 // this stuff can be customised to show whatever you want....
-if ($_SESSION['userlevel'] >= '5') {
+if (is_read() || is_admin()) {
     $sql  = "SELECT * FROM ports AS I, devices AS D WHERE `ifAlias` like 'L2TP: %' AND I.device_id = D.device_id AND D.hostname LIKE '%";
     $sql .= $config['mydomain']."' ORDER BY I.ifAlias";
     unset($seperator);

--- a/html/pages/front/globe.php
+++ b/html/pages/front/globe.php
@@ -95,7 +95,7 @@ if ($config['enable_syslog']) {
     echo("</div>");
     echo("</div>");
 } else {
-    if ($_SESSION['userlevel'] == '10') {
+    if (is_admin()) {
         $query = "SELECT *,DATE_FORMAT(datetime, '".$config['dateformat']['mysql']['compact']."') as humandate  FROM `eventlog` ORDER BY `datetime` DESC LIMIT 0,15";
     } else {
         $query = "SELECT *,DATE_FORMAT(datetime, '".$config['dateformat']['mysql']['compact']."') as humandate  FROM `eventlog` AS E, devices_perms AS P WHERE E.host =

--- a/html/pages/front/jt.php
+++ b/html/pages/front/jt.php
@@ -115,7 +115,7 @@ echo '</div>
     <td bgcolor=#e5e5e5 width=470 valign=top>';
 
 // this stuff can be customised to show whatever you want....
-if ($_SESSION['userlevel'] >= '5') {
+if (is_read() || is_admin()) {
     $sql = "SELECT * FROM ports AS I, devices AS D WHERE `ifAlias` like 'Transit: %' AND I.device_id = D.device_id ORDER BY I.ifAlias";
     unset($seperator);
     foreach (dbFetchRows($sql) as $interface) {

--- a/html/pages/front/map.php
+++ b/html/pages/front/map.php
@@ -4,12 +4,12 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>. */
 
@@ -184,7 +184,7 @@ if ($config['enable_syslog']) {
     echo("</div>");
     echo("</div>");
 } else {
-    if ($_SESSION['userlevel'] == '10') {
+    if (is_admin()) {
         $query = "SELECT *,DATE_FORMAT(datetime, '".$config['dateformat']['mysql']['compact']."') as humandate  FROM `eventlog` ORDER BY `datetime` DESC LIMIT 0,15";
     } else {
         $query = "SELECT *,DATE_FORMAT(datetime, '".$config['dateformat']['mysql']['compact']."') as humandate  FROM `eventlog` AS E, devices_perms AS P WHERE E.host =

--- a/html/pages/front/traffic.php
+++ b/html/pages/front/traffic.php
@@ -109,7 +109,7 @@ echo '</div>
     <td bgcolor=#e5e5e5 width=470 valign=top>';
 
 // this stuff can be customised to show whatever you want....
-if ($_SESSION['userlevel'] >= '5') {
+if (is_read() || is_admin()) {
     $sql = "SELECT * FROM ports AS I, devices AS D WHERE `ifAlias` like 'Transit: %' AND I.device_id = D.device_id ORDER BY I.ifAlias";
     unset($seperator);
     foreach (dbFetchRows($sql) as $interface) {

--- a/html/pages/locations.inc.php
+++ b/html/pages/locations.inc.php
@@ -37,7 +37,7 @@ print_optionbar_end();
 echo '<table cellpadding="7" cellspacing="0" class="devicetable" width="100%">';
 
 foreach (getlocations() as $location) {
-    if ($_SESSION['userlevel'] >= '10') {
+    if (is_admin()) {
         $num        = dbFetchCell('SELECT COUNT(device_id) FROM devices WHERE location = ?', array($location));
         $net        = dbFetchCell("SELECT COUNT(device_id) FROM devices WHERE location = ? AND type = 'network'", array($location));
         $srv        = dbFetchCell("SELECT COUNT(device_id) FROM devices WHERE location = ? AND type = 'server'", array($location));

--- a/html/pages/notifications.inc.php
+++ b/html/pages/notifications.inc.php
@@ -30,7 +30,7 @@ $notifications = new ObjectCache('notifications');
   <div class="row">
     <div class="col-md-12">
       <h1><a href="/notifications">Notifications</a></h1>
-      <h4><strong class="count-notif"><?php echo $notifications['count']; ?></strong> Unread Notifications <?php echo ($_SESSION['userlevel'] == 10 ? '<button class="btn btn-success pull-right new-notif" style="margin-top:-10px;">New</button>' : ''); ?></h4>
+      <h4><strong class="count-notif"><?php echo $notifications['count']; ?></strong> Unread Notifications <?php echo (is_admin() ? '<button class="btn btn-success pull-right new-notif" style="margin-top:-10px;">New</button>' : ''); ?></h4>
       <hr/>
     </div>
   </div>
@@ -157,7 +157,7 @@ foreach (array_reverse($notifications['read']) as $notif) {
     }
     echo  " id='${notif['notifications_id']}'>${notif['title']}";
 
-    if ($_SESSION['userlevel'] == 10) {
+    if (is_admin()) {
         echo '<span class="pull-right"><button class="btn btn-primary fa fa-bell-o stick-notif" data-toggle="tooltip" data-placement="bottom" title="Mark as Sticky" style="margin-top:-10px;"></button></span>';
     }
 ?>

--- a/html/pages/plugin/admin.inc.php
+++ b/html/pages/plugin/admin.inc.php
@@ -1,6 +1,6 @@
 <?php
 
-if ($_SESSION['userlevel'] >= '10') {
+if (is_admin()) {
     // Scan for new plugins and add to the database
     $new_plugins = scan_new_plugins();
 

--- a/html/pages/ports.inc.php
+++ b/html/pages/ports.inc.php
@@ -86,7 +86,7 @@ if ((isset($vars['searchbar']) && $vars['searchbar'] != "hide") || !isset($vars[
         <option value=''>All Devices</option>
 <?php
 
-if ($_SESSION['userlevel'] >= 5) {
+if (is_read() || is_admin()) {
     $results = dbFetchRows("SELECT `device_id`,`hostname`, `sysName` FROM `devices` ORDER BY `hostname`");
 } else {
     $results = dbFetchRows("SELECT `D`.`device_id`,`D`.`hostname`, `D`.`sysname` FROM `devices` AS `D`, `devices_perms` AS `P` WHERE `P`.`user_id` = ? AND `P`.`device_id` = `D`.`device_id` ORDER BY `hostname`", array($_SESSION['user_id']));
@@ -99,7 +99,7 @@ foreach ($results as $data) {
     echo(">".format_hostname($data)."</option>");
 }
 
-if ($_SESSION['userlevel'] < 5) {
+if (is_normal_user()) {
     $results = dbFetchRows("SELECT `D`.`device_id`,`D`.`hostname`, `D`.`sysName` FROM `ports` AS `I` JOIN `devices` AS `D` ON `D`.`device_id`=`I`.`device_id` JOIN `ports_perms` AS `PP` ON `PP`.`port_id`=`I`.`port_id` WHERE `PP`.`user_id` = ? AND `PP`.`port_id` = `I`.`port_id` ORDER BY `hostname`", array($_SESSION['user_id']));
 } else {
     $results = array();

--- a/html/pages/preferences.inc.php
+++ b/html/pages/preferences.inc.php
@@ -9,7 +9,7 @@ $pagetitle[] = 'Preferences';
 echo '<h2>User Preferences</h2>';
 echo '<hr>';
 
-if ($_SESSION['userlevel'] == 11) {
+if (is_demo_user()) {
     demo_account();
 } else {
     if ($_POST['action'] == 'changepass') {
@@ -207,15 +207,11 @@ echo "
 echo "<h3>Device Permissions</h3>";
 echo "<hr>";
 echo "<div style='background-color: #e5e5e5; border: solid #e5e5e5 10px;  margin-bottom:10px;'>";
-if ($_SESSION['userlevel'] == '10') {
+if (is_admin() && !is_demo_user()) {
     echo "<strong class='blue'>Global Administrative Access</strong>";
-}
-
-if ($_SESSION['userlevel'] == '5') {
+} elseif (is_read()) {
     echo "<strong class='green'>Global Viewing Access</strong>";
-}
-
-if ($_SESSION['userlevel'] == '1') {
+} elseif (is_normal_user()) {
     foreach (dbFetchRows('SELECT * FROM `devices_perms` AS P, `devices` AS D WHERE `user_id` = ? AND P.device_id = D.device_id', array($_SESSION['user_id'])) as $perm) {
     // FIXME generatedevicelink?
         echo "<a href='device/device=".$perm['device_id']."'>".$perm['hostname'].'</a><br />';

--- a/html/pages/routing/bgp.inc.php
+++ b/html/pages/routing/bgp.inc.php
@@ -1,9 +1,10 @@
 <?php
 
+use Delight\Cookie\Session;
 use LibreNMS\Exceptions\InvalidIpException;
 use LibreNMS\Util\IPv6;
 
-if ($_SESSION['userlevel'] < '5') {
+if (Session::get('userlevel') < '5') {
     include 'includes/error-no-perm.inc.php';
 } else {
     $link_array = array(

--- a/html/pages/routing/vrf.inc.php
+++ b/html/pages/routing/vrf.inc.php
@@ -1,6 +1,6 @@
 <?php
 
-if ($_SESSION['userlevel'] >= '5') {
+if (is_read() || is_admin()) {
     if (!isset($_GET['optb'])) {
         $_GET['optb'] = 'all';
     }

--- a/html/pages/services.inc.php
+++ b/html/pages/services.inc.php
@@ -94,7 +94,7 @@ if (isset($state)) {
 ?>
 <div class="row col-sm-12"><span id="message"></span></div>
 <?php
-if ($_SESSION['userlevel'] >= '5') {
+if (is_read() || is_admin()) {
     $host_sql = 'SELECT `D`.`device_id`,`D`.`hostname`,`D`.`sysName` FROM devices AS D, services AS S WHERE D.device_id = S.device_id GROUP BY `D`.`hostname`, `D`.`device_id` ORDER BY D.hostname';
     $host_par = array();
 } else {

--- a/html/pages/settings.inc.php
+++ b/html/pages/settings.inc.php
@@ -104,7 +104,7 @@ if (is_admin() === true) {
 
         echo '<div class="table-responsive">' . a2t($config) . '</div>';
 
-        if ($debug && $_SESSION['userlevel'] >= '10') {
+        if ($debug && is_admin()) {
             echo("<pre>");
             print_r($config);
             echo("</pre>");

--- a/html/pages/syslog.inc.php
+++ b/html/pages/syslog.inc.php
@@ -4,7 +4,7 @@ $no_refresh = true;
 
 $param = array();
 
-if ($vars['action'] == 'expunge' && $_SESSION['userlevel'] >= '10') {
+if ($vars['action'] == 'expunge' && is_admin()) {
     dbQuery('TRUNCATE TABLE `syslog`');
     print_message('syslog truncated');
 }

--- a/includes/caches/alerts.inc.php
+++ b/includes/caches/alerts.inc.php
@@ -1,6 +1,6 @@
 <?php
 
-if ($_SESSION['userlevel'] >= 5) {
+if (is_read() || is_admin()) {
     $data['active_count'] = array('query' => 'SELECT COUNT(`alerts`.`id`)  FROM `alerts` LEFT JOIN `devices` ON `alerts`.`device_id`=`devices`.`device_id`  RIGHT JOIN `alert_rules` ON `alerts`.`rule_id`=`alert_rules`.`id` WHERE 1 AND `alerts`.`state` NOT IN (0,1)');
 } else {
     $data['active_count'] = array(

--- a/includes/caches/devices.inc.php
+++ b/includes/caches/devices.inc.php
@@ -1,6 +1,6 @@
 <?php
 
-if ($_SESSION['userlevel'] >= 5) {
+if (is_read() || is_admin()) {
     $data['count'] = array('query' => 'SELECT COUNT(*) FROM devices');
 
     $data['up'] = array('query' => "SELECT COUNT(*) FROM devices WHERE `status` = '1' AND `ignore` = '0'  AND `disabled` = '0'",);

--- a/includes/caches/ports.inc.php
+++ b/includes/caches/ports.inc.php
@@ -1,6 +1,6 @@
 <?php
 
-if ($_SESSION['userlevel'] >= 5) {
+if (is_read() || is_admin()) {
     $data['count'] = array('query' => "SELECT COUNT(*) FROM ports WHERE `deleted` = '0'");
 
     $data['up'] = array('query' => "SELECT COUNT(*) FROM ports AS I, devices AS D WHERE I.`deleted` = '0' AND D.`device_id` = I.`device_id` AND I.`ignore` = '0' AND D.`ignore` = '0' AND I.`ifOperStatus` = 'up'",);

--- a/includes/caches/services.inc.php
+++ b/includes/caches/services.inc.php
@@ -1,6 +1,6 @@
 <?php
 
-if ($_SESSION['userlevel'] >= 5) {
+if (is_read() || is_admin()) {
     $data['count']    = array( 'query' => 'SELECT COUNT(*) FROM services');
     $data['up']       = array( 'query' => "SELECT COUNT(*) FROM services WHERE `service_ignore` = '0' AND `service_disabled` = '0' AND `service_status` = '0'");
     $data['down']     = array( 'query' => "SELECT COUNT(*) FROM services WHERE `service_ignore` = '0' AND `service_disabled` = '0' AND `service_status` = '2'");


### PR DESCRIPTION
Remove generic session helpers. I think they should be replaced with more specific functions like is_admin()

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [ ] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
